### PR TITLE
Correct broken link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -43,7 +43,7 @@ href = "https://github.com/z-shell"
 icon = "https://github.com/z-shell.png"
 [[params.links]]
 title = "digital-clouds"
-href = "https://github,com/digital-clouds"
+href = "https://github.com/digital-clouds"
 icon = "https://github.com/digital-clouds.png"
 #[[params.links]]
 #title = "ss-o"


### PR DESCRIPTION
There was an error in the link. 

```
- https://github,com/digital-clouds
+ https://github.com/digital-clouds
```